### PR TITLE
feat: Add comprehensive API test suite for all allowance endpoints

### DIFF
--- a/tests/test_api_create_allowance.py
+++ b/tests/test_api_create_allowance.py
@@ -1,0 +1,216 @@
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException
+
+from ..views_api_minimal import allowance_api_router
+from ..models import CreateAllowanceData, Allowance
+
+
+@pytest.fixture
+def client():
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(allowance_api_router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_wallet():
+    wallet = AsyncMock()
+    wallet.wallet.id = "test_wallet_id"
+    return wallet
+
+
+@pytest.fixture
+def valid_allowance_data():
+    return {
+        "name": "Test Allowance",
+        "lightning_address": "test@example.com",
+        "amount": 1000,
+        "currency": "sats",
+        "start_date": "2024-01-01T00:00:00",
+        "frequency_type": "daily",
+        "next_payment_date": "2024-01-02T00:00:00",
+        "memo": "Test memo",
+        "active": True
+    }
+
+
+@pytest.fixture
+def mock_created_allowance():
+    return Allowance(
+        id="new_allowance_id",
+        name="Test Allowance",
+        wallet="test_wallet_id",
+        lightning_address="test@example.com",
+        amount=1000,
+        currency="sats",
+        start_date=datetime(2024, 1, 1),
+        frequency_type="daily",
+        next_payment_date=datetime(2024, 1, 2),
+        memo="Test memo",
+        active=True
+    )
+
+
+class TestCreateAllowanceAPI:
+    
+    @patch('..views_api_minimal.create_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_create_allowance_success(self, mock_require_admin_key, mock_create_allowance, client, mock_wallet, valid_allowance_data, mock_created_allowance):
+        """Test successful creation of allowance"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_create_allowance.return_value = mock_created_allowance
+        
+        # Make request
+        response = client.post("/api/v1/allowance", json=valid_allowance_data)
+        
+        # Assertions
+        assert response.status_code == 201
+        data = response.json()
+        assert data["id"] == "new_allowance_id"
+        assert data["name"] == "Test Allowance"
+        assert data["wallet"] == "test_wallet_id"
+        assert data["amount"] == 1000
+        
+        # Verify mock calls
+        mock_create_allowance.assert_called_once()
+    
+    @patch('..views_api_minimal.require_admin_key')
+    def test_create_allowance_invalid_admin_key(self, mock_require_admin_key, client, valid_allowance_data):
+        """Test creating allowance with invalid admin key"""
+        # Setup mocks to raise authentication error
+        mock_require_admin_key.side_effect = HTTPException(status_code=403, detail="Admin key required")
+        
+        # Make request
+        response = client.post("/api/v1/allowance", json=valid_allowance_data)
+        
+        # Assertions
+        assert response.status_code == 403
+    
+    @patch('..views_api_minimal.require_admin_key')
+    def test_create_allowance_missing_required_fields(self, mock_require_admin_key, client, mock_wallet):
+        """Test creating allowance with missing required fields"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        
+        # Test missing name
+        invalid_data = {
+            "lightning_address": "test@example.com",
+            "amount": 1000,
+            "currency": "sats",
+            "start_date": "2024-01-01T00:00:00",
+            "frequency_type": "daily",
+            "next_payment_date": "2024-01-02T00:00:00",
+            "memo": "Test memo",
+            "active": True
+        }
+        
+        response = client.post("/api/v1/allowance", json=invalid_data)
+        assert response.status_code == 422
+    
+    @patch('..views_api_minimal.require_admin_key')
+    def test_create_allowance_invalid_amount(self, mock_require_admin_key, client, mock_wallet, valid_allowance_data):
+        """Test creating allowance with invalid amount"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        
+        # Test negative amount
+        valid_allowance_data["amount"] = -100
+        response = client.post("/api/v1/allowance", json=valid_allowance_data)
+        assert response.status_code == 422
+        
+        # Test zero amount
+        valid_allowance_data["amount"] = 0
+        response = client.post("/api/v1/allowance", json=valid_allowance_data)
+        assert response.status_code == 422
+    
+    @patch('..views_api_minimal.require_admin_key')
+    def test_create_allowance_invalid_lightning_address(self, mock_require_admin_key, client, mock_wallet, valid_allowance_data):
+        """Test creating allowance with invalid lightning address"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        
+        # Test empty lightning address
+        valid_allowance_data["lightning_address"] = ""
+        response = client.post("/api/v1/allowance", json=valid_allowance_data)
+        assert response.status_code == 422
+        
+        # Test missing lightning address
+        del valid_allowance_data["lightning_address"]
+        response = client.post("/api/v1/allowance", json=valid_allowance_data)
+        assert response.status_code == 422
+    
+    @patch('..views_api_minimal.require_admin_key')
+    def test_create_allowance_invalid_dates(self, mock_require_admin_key, client, mock_wallet, valid_allowance_data):
+        """Test creating allowance with invalid date formats"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        
+        # Test invalid date format
+        valid_allowance_data["start_date"] = "invalid-date"
+        response = client.post("/api/v1/allowance", json=valid_allowance_data)
+        assert response.status_code == 422
+    
+    @patch('..views_api_minimal.create_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_create_allowance_database_error(self, mock_require_admin_key, mock_create_allowance, client, mock_wallet, valid_allowance_data):
+        """Test creating allowance when database error occurs"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_create_allowance.side_effect = Exception("Database connection failed")
+        
+        # Make request
+        response = client.post("/api/v1/allowance", json=valid_allowance_data)
+        
+        # Assertions
+        assert response.status_code == 500
+    
+    @patch('..views_api_minimal.create_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_create_allowance_with_custom_wallet(self, mock_require_admin_key, mock_create_allowance, client, mock_wallet, valid_allowance_data, mock_created_allowance):
+        """Test creating allowance with custom wallet ID"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_created_allowance.wallet = "custom_wallet_id"
+        mock_create_allowance.return_value = mock_created_allowance
+        
+        # Add custom wallet to data
+        valid_allowance_data["wallet"] = "custom_wallet_id"
+        
+        # Make request
+        response = client.post("/api/v1/allowance", json=valid_allowance_data)
+        
+        # Assertions
+        assert response.status_code == 201
+        data = response.json()
+        assert data["wallet"] == "custom_wallet_id"
+    
+    @patch('..views_api_minimal.create_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_create_allowance_minimal_data(self, mock_require_admin_key, mock_create_allowance, client, mock_wallet, mock_created_allowance):
+        """Test creating allowance with minimal required data"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_create_allowance.return_value = mock_created_allowance
+        
+        # Minimal required data
+        minimal_data = {
+            "name": "Minimal Allowance",
+            "lightning_address": "minimal@example.com",
+            "amount": 500,
+            "currency": "sats",
+            "start_date": "2024-01-01T00:00:00",
+            "frequency_type": "weekly",
+            "next_payment_date": "2024-01-08T00:00:00",
+            "memo": "Minimal memo"
+        }
+        
+        # Make request
+        response = client.post("/api/v1/allowance", json=minimal_data)
+        
+        # Assertions
+        assert response.status_code == 201

--- a/tests/test_api_delete_allowance.py
+++ b/tests/test_api_delete_allowance.py
@@ -1,0 +1,208 @@
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException
+
+from ..views_api_minimal import allowance_api_router
+from ..models import Allowance
+
+
+@pytest.fixture
+def client():
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(allowance_api_router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_wallet():
+    wallet = AsyncMock()
+    wallet.wallet.id = "test_wallet_id"
+    return wallet
+
+
+@pytest.fixture
+def mock_allowance():
+    return Allowance(
+        id="test_allowance_id",
+        name="Test Allowance",
+        wallet="test_wallet_id",
+        lightning_address="test@example.com",
+        amount=1000,
+        currency="sats",
+        start_date=datetime(2024, 1, 1),
+        frequency_type="daily",
+        next_payment_date=datetime(2024, 1, 2),
+        memo="Test memo",
+        active=True
+    )
+
+
+class TestDeleteAllowanceAPI:
+    
+    @patch('..views_api_minimal.delete_allowance')
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_delete_allowance_success(self, mock_require_admin_key, mock_get_allowance, mock_delete_allowance, client, mock_wallet, mock_allowance):
+        """Test successful deletion of allowance"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.return_value = mock_allowance
+        mock_delete_allowance.return_value = None
+        
+        # Make request
+        response = client.delete("/api/v1/allowance/test_allowance_id")
+        
+        # Assertions - The minimal API returns a JSON message, not 204
+        assert response.status_code == 200
+        data = response.json()
+        assert data["message"] == "Allowance deleted"
+        
+        # Verify mock calls
+        mock_get_allowance.assert_called_once_with("test_allowance_id")
+        mock_delete_allowance.assert_called_once_with("test_allowance_id")
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_delete_allowance_not_found(self, mock_require_admin_key, mock_get_allowance, client, mock_wallet):
+        """Test deleting allowance that doesn't exist"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.return_value = None
+        
+        # Make request
+        response = client.delete("/api/v1/allowance/nonexistent_id")
+        
+        # Assertions
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Allowance does not exist."
+        
+        # Verify mock calls
+        mock_get_allowance.assert_called_once_with("nonexistent_id")
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_delete_allowance_wrong_wallet(self, mock_require_admin_key, mock_get_allowance, client, mock_allowance):
+        """Test deleting allowance from different wallet (forbidden)"""
+        # Setup mocks - different wallet ID
+        wrong_wallet = AsyncMock()
+        wrong_wallet.wallet.id = "different_wallet_id"
+        
+        mock_require_admin_key.return_value = wrong_wallet
+        mock_get_allowance.return_value = mock_allowance  # Has wallet "test_wallet_id"
+        
+        # Make request
+        response = client.delete("/api/v1/allowance/test_allowance_id")
+        
+        # Assertions
+        assert response.status_code == 403
+        data = response.json()
+        assert data["detail"] == "Not your allowance."
+        
+        # Verify mock calls
+        mock_get_allowance.assert_called_once_with("test_allowance_id")
+    
+    @patch('..views_api_minimal.require_admin_key')
+    def test_delete_allowance_invalid_admin_key(self, mock_require_admin_key, client):
+        """Test deleting allowance with invalid admin key"""
+        # Setup mocks to raise authentication error
+        mock_require_admin_key.side_effect = HTTPException(status_code=403, detail="Admin key required")
+        
+        # Make request
+        response = client.delete("/api/v1/allowance/test_allowance_id")
+        
+        # Assertions
+        assert response.status_code == 403
+    
+    @patch('..views_api_minimal.require_admin_key')
+    def test_delete_allowance_empty_id(self, mock_require_admin_key, client, mock_wallet):
+        """Test deleting allowance with empty ID"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        
+        # Make request with empty ID
+        response = client.delete("/api/v1/allowance/")
+        
+        # Assertions - should return 404 for malformed URL
+        assert response.status_code == 404
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_delete_allowance_database_error_on_get(self, mock_require_admin_key, mock_get_allowance, client, mock_wallet):
+        """Test deleting allowance when database error occurs during get"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.side_effect = Exception("Database connection failed")
+        
+        # Make request
+        response = client.delete("/api/v1/allowance/test_allowance_id")
+        
+        # Assertions
+        assert response.status_code == 500
+    
+    @patch('..views_api_minimal.delete_allowance')
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_delete_allowance_database_error_on_delete(self, mock_require_admin_key, mock_get_allowance, mock_delete_allowance, client, mock_wallet, mock_allowance):
+        """Test deleting allowance when database error occurs during delete"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.return_value = mock_allowance
+        mock_delete_allowance.side_effect = Exception("Database connection failed")
+        
+        # Make request
+        response = client.delete("/api/v1/allowance/test_allowance_id")
+        
+        # Assertions
+        assert response.status_code == 500
+    
+    @patch('..views_api_minimal.delete_allowance')
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_delete_allowance_special_characters(self, mock_require_admin_key, mock_get_allowance, mock_delete_allowance, client, mock_wallet, mock_allowance):
+        """Test deleting allowance with special characters in ID"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_allowance.id = "test-allowance_123"
+        mock_get_allowance.return_value = mock_allowance
+        mock_delete_allowance.return_value = None
+        
+        # Make request
+        response = client.delete("/api/v1/allowance/test-allowance_123")
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        assert data["message"] == "Allowance deleted"
+        
+        # Verify mock calls
+        mock_get_allowance.assert_called_once_with("test-allowance_123")
+        mock_delete_allowance.assert_called_once_with("test-allowance_123")
+    
+    @patch('..views_api_minimal.delete_allowance')
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_delete_allowance_wallet_permission_check(self, mock_require_admin_key, mock_get_allowance, mock_delete_allowance, client, mock_wallet, mock_allowance):
+        """Test that wallet permission is properly checked before deletion"""
+        # Setup mocks - same wallet ID
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.return_value = mock_allowance
+        mock_delete_allowance.return_value = None
+        
+        # Verify allowance wallet matches admin wallet
+        assert mock_allowance.wallet == mock_wallet.wallet.id
+        
+        # Make request
+        response = client.delete("/api/v1/allowance/test_allowance_id")
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        assert data["message"] == "Allowance deleted"
+        
+        # Verify that get_allowance was called to check permissions
+        mock_get_allowance.assert_called_once_with("test_allowance_id")
+        mock_delete_allowance.assert_called_once_with("test_allowance_id")

--- a/tests/test_api_get_allowance.py
+++ b/tests/test_api_get_allowance.py
@@ -1,0 +1,147 @@
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException
+
+from ..views_api_minimal import allowance_api_router
+from ..models import Allowance
+
+
+@pytest.fixture
+def client():
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(allowance_api_router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_wallet():
+    wallet = AsyncMock()
+    wallet.wallet.id = "test_wallet_id"
+    return wallet
+
+
+@pytest.fixture
+def mock_allowance():
+    return Allowance(
+        id="test_allowance_id",
+        name="Test Allowance",
+        wallet="test_wallet_id",
+        lightning_address="test@example.com",
+        amount=1000,
+        currency="sats",
+        start_date=datetime(2024, 1, 1),
+        frequency_type="daily",
+        next_payment_date=datetime(2024, 1, 2),
+        memo="Test memo",
+        active=True
+    )
+
+
+class TestGetAllowanceAPI:
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_invoice_key')
+    def test_get_allowance_success(self, mock_require_invoice_key, mock_get_allowance, client, mock_wallet, mock_allowance):
+        """Test successful retrieval of a single allowance"""
+        # Setup mocks
+        mock_require_invoice_key.return_value = mock_wallet
+        mock_get_allowance.return_value = mock_allowance
+        
+        # Make request
+        response = client.get("/api/v1/allowance/test_allowance_id")
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == "test_allowance_id"
+        assert data["name"] == "Test Allowance"
+        assert data["wallet"] == "test_wallet_id"
+        assert data["lightning_address"] == "test@example.com"
+        assert data["amount"] == 1000
+        assert data["currency"] == "sats"
+        assert data["frequency_type"] == "daily"
+        assert data["memo"] == "Test memo"
+        assert data["active"] is True
+        
+        # Verify mock calls
+        mock_get_allowance.assert_called_once_with("test_allowance_id")
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_invoice_key')
+    def test_get_allowance_not_found(self, mock_require_invoice_key, mock_get_allowance, client, mock_wallet):
+        """Test getting allowance that doesn't exist"""
+        # Setup mocks
+        mock_require_invoice_key.return_value = mock_wallet
+        mock_get_allowance.return_value = None
+        
+        # Make request
+        response = client.get("/api/v1/allowance/nonexistent_id")
+        
+        # Assertions
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Allowance does not exist."
+        
+        # Verify mock calls
+        mock_get_allowance.assert_called_once_with("nonexistent_id")
+    
+    @patch('..views_api_minimal.require_invoice_key')
+    def test_get_allowance_invalid_key(self, mock_require_invoice_key, client):
+        """Test getting allowance with invalid API key"""
+        # Setup mocks to raise authentication error
+        mock_require_invoice_key.side_effect = HTTPException(status_code=401, detail="Invalid key")
+        
+        # Make request
+        response = client.get("/api/v1/allowance/test_allowance_id")
+        
+        # Assertions
+        assert response.status_code == 401
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_invoice_key')
+    def test_get_allowance_database_error(self, mock_require_invoice_key, mock_get_allowance, client, mock_wallet):
+        """Test getting allowance when database error occurs"""
+        # Setup mocks
+        mock_require_invoice_key.return_value = mock_wallet
+        mock_get_allowance.side_effect = Exception("Database connection failed")
+        
+        # Make request
+        response = client.get("/api/v1/allowance/test_allowance_id")
+        
+        # Assertions
+        assert response.status_code == 500
+    
+    @patch('..views_api_minimal.require_invoice_key')
+    def test_get_allowance_empty_id(self, mock_require_invoice_key, client, mock_wallet):
+        """Test getting allowance with empty ID"""
+        # Setup mocks
+        mock_require_invoice_key.return_value = mock_wallet
+        
+        # Make request with empty ID
+        response = client.get("/api/v1/allowance/")
+        
+        # Assertions - should return 404 for malformed URL
+        assert response.status_code == 404
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_invoice_key')
+    def test_get_allowance_special_characters(self, mock_require_invoice_key, mock_get_allowance, client, mock_wallet, mock_allowance):
+        """Test getting allowance with special characters in ID"""
+        # Setup mocks
+        mock_require_invoice_key.return_value = mock_wallet
+        mock_allowance.id = "test-allowance_123"
+        mock_get_allowance.return_value = mock_allowance
+        
+        # Make request
+        response = client.get("/api/v1/allowance/test-allowance_123")
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == "test-allowance_123"
+        
+        # Verify mock calls
+        mock_get_allowance.assert_called_once_with("test-allowance_123")

--- a/tests/test_api_list_allowances.py
+++ b/tests/test_api_list_allowances.py
@@ -1,0 +1,124 @@
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException
+
+from ..views_api_minimal import allowance_api_router
+from ..models import Allowance
+
+
+@pytest.fixture
+def client():
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(allowance_api_router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_wallet():
+    wallet = AsyncMock()
+    wallet.wallet.id = "test_wallet_id"
+    return wallet
+
+
+@pytest.fixture
+def mock_allowances():
+    return [
+        Allowance(
+            id="allowance_1",
+            name="Test Allowance 1",
+            wallet="test_wallet_id",
+            lightning_address="test1@example.com",
+            amount=1000,
+            currency="sats",
+            start_date=datetime(2024, 1, 1),
+            frequency_type="daily",
+            next_payment_date=datetime(2024, 1, 2),
+            memo="Test memo 1",
+            active=True
+        ),
+        Allowance(
+            id="allowance_2",
+            name="Test Allowance 2",
+            wallet="test_wallet_id",
+            lightning_address="test2@example.com",
+            amount=2000,
+            currency="sats",
+            start_date=datetime(2024, 1, 1),
+            frequency_type="weekly",
+            next_payment_date=datetime(2024, 1, 8),
+            memo="Test memo 2",
+            active=False
+        )
+    ]
+
+
+class TestListAllowancesAPI:
+    
+    @patch('..views_api_minimal.get_allowances')
+    @patch('..views_api_minimal.require_invoice_key')
+    def test_list_allowances_success(self, mock_require_invoice_key, mock_get_allowances, client, mock_wallet, mock_allowances):
+        """Test successful listing of allowances"""
+        # Setup mocks
+        mock_require_invoice_key.return_value = mock_wallet
+        mock_get_allowances.return_value = mock_allowances
+        
+        # Make request
+        response = client.get("/api/v1/allowance")
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert data[0]["id"] == "allowance_1"
+        assert data[0]["name"] == "Test Allowance 1"
+        assert data[1]["id"] == "allowance_2"
+        assert data[1]["name"] == "Test Allowance 2"
+        
+        # Verify mock calls
+        mock_get_allowances.assert_called_once_with([mock_wallet.wallet.id])
+    
+    @patch('..views_api_minimal.get_allowances')
+    @patch('..views_api_minimal.require_invoice_key')
+    def test_list_allowances_empty(self, mock_require_invoice_key, mock_get_allowances, client, mock_wallet):
+        """Test listing allowances when none exist"""
+        # Setup mocks
+        mock_require_invoice_key.return_value = mock_wallet
+        mock_get_allowances.return_value = []
+        
+        # Make request
+        response = client.get("/api/v1/allowance")
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 0
+        assert data == []
+    
+    @patch('..views_api_minimal.require_invoice_key')
+    def test_list_allowances_invalid_key(self, mock_require_invoice_key, client):
+        """Test listing allowances with invalid API key"""
+        # Setup mocks to raise authentication error
+        mock_require_invoice_key.side_effect = HTTPException(status_code=401, detail="Invalid key")
+        
+        # Make request
+        response = client.get("/api/v1/allowance")
+        
+        # Assertions
+        assert response.status_code == 401
+    
+    @patch('..views_api_minimal.get_allowances')
+    @patch('..views_api_minimal.require_invoice_key')
+    def test_list_allowances_database_error(self, mock_require_invoice_key, mock_get_allowances, client, mock_wallet):
+        """Test listing allowances when database error occurs"""
+        # Setup mocks
+        mock_require_invoice_key.return_value = mock_wallet
+        mock_get_allowances.side_effect = Exception("Database connection failed")
+        
+        # Make request
+        response = client.get("/api/v1/allowance")
+        
+        # Assertions
+        assert response.status_code == 500

--- a/tests/test_api_update_allowance.py
+++ b/tests/test_api_update_allowance.py
@@ -1,0 +1,251 @@
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException
+
+from ..views_api_minimal import allowance_api_router
+from ..models import CreateAllowanceData, Allowance
+
+
+@pytest.fixture
+def client():
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(allowance_api_router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_wallet():
+    wallet = AsyncMock()
+    wallet.wallet.id = "test_wallet_id"
+    return wallet
+
+
+@pytest.fixture
+def mock_allowance():
+    return Allowance(
+        id="test_allowance_id",
+        name="Test Allowance",
+        wallet="test_wallet_id",
+        lightning_address="test@example.com",
+        amount=1000,
+        currency="sats",
+        start_date=datetime(2024, 1, 1),
+        frequency_type="daily",
+        next_payment_date=datetime(2024, 1, 2),
+        memo="Test memo",
+        active=True
+    )
+
+
+@pytest.fixture
+def update_data():
+    return {
+        "name": "Updated Allowance",
+        "lightning_address": "updated@example.com",
+        "amount": 2000,
+        "currency": "sats",
+        "start_date": "2024-02-01T00:00:00",
+        "frequency_type": "weekly",
+        "next_payment_date": "2024-02-08T00:00:00",
+        "memo": "Updated memo",
+        "active": False
+    }
+
+
+@pytest.fixture
+def mock_updated_allowance():
+    return Allowance(
+        id="test_allowance_id",
+        name="Updated Allowance",
+        wallet="test_wallet_id",
+        lightning_address="updated@example.com",
+        amount=2000,
+        currency="sats",
+        start_date=datetime(2024, 2, 1),
+        frequency_type="weekly",
+        next_payment_date=datetime(2024, 2, 8),
+        memo="Updated memo",
+        active=False
+    )
+
+
+class TestUpdateAllowanceAPI:
+    
+    @patch('..views_api_minimal.update_allowance')
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_update_allowance_success(self, mock_require_admin_key, mock_get_allowance, mock_update_allowance, client, mock_wallet, mock_allowance, update_data, mock_updated_allowance):
+        """Test successful update of allowance"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.return_value = mock_allowance
+        mock_update_allowance.return_value = mock_updated_allowance
+        
+        # Make request
+        response = client.put("/api/v1/allowance/test_allowance_id", json=update_data)
+        
+        # Assertions
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Updated Allowance"
+        assert data["amount"] == 2000
+        assert data["lightning_address"] == "updated@example.com"
+        assert data["active"] is False
+        
+        # Verify mock calls
+        mock_get_allowance.assert_called_once_with("test_allowance_id")
+        mock_update_allowance.assert_called_once()
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_update_allowance_not_found(self, mock_require_admin_key, mock_get_allowance, client, mock_wallet, update_data):
+        """Test updating allowance that doesn't exist"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.return_value = None
+        
+        # Make request
+        response = client.put("/api/v1/allowance/nonexistent_id", json=update_data)
+        
+        # Assertions
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Allowance does not exist."
+    
+    @patch('..views_api_minimal.require_admin_key')
+    def test_update_allowance_empty_id(self, mock_require_admin_key, client, mock_wallet, update_data):
+        """Test updating allowance with empty ID"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        
+        # Make request - empty ID should cause 404
+        response = client.put("/api/v1/allowance/", json=update_data)
+        
+        # Assertions
+        assert response.status_code == 404
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_update_allowance_wrong_wallet(self, mock_require_admin_key, mock_get_allowance, client, mock_allowance, update_data):
+        """Test updating allowance from different wallet (forbidden)"""
+        # Setup mocks - different wallet ID
+        wrong_wallet = AsyncMock()
+        wrong_wallet.wallet.id = "different_wallet_id"
+        
+        mock_require_admin_key.return_value = wrong_wallet
+        mock_get_allowance.return_value = mock_allowance  # Has wallet "test_wallet_id"
+        
+        # Make request
+        response = client.put("/api/v1/allowance/test_allowance_id", json=update_data)
+        
+        # Assertions
+        assert response.status_code == 403
+        data = response.json()
+        assert data["detail"] == "Not your allowance."
+    
+    @patch('..views_api_minimal.require_admin_key')
+    def test_update_allowance_invalid_key(self, mock_require_admin_key, client, update_data):
+        """Test updating allowance with invalid API key"""
+        # Setup mocks to raise authentication error
+        mock_require_admin_key.side_effect = HTTPException(status_code=401, detail="Invalid key")
+        
+        # Make request
+        response = client.put("/api/v1/allowance/test_allowance_id", json=update_data)
+        
+        # Assertions
+        assert response.status_code == 401
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_update_allowance_invalid_data(self, mock_require_admin_key, mock_get_allowance, client, mock_wallet, mock_allowance):
+        """Test updating allowance with invalid data"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.return_value = mock_allowance
+        
+        # Test invalid amount
+        invalid_data = {
+            "name": "Updated Allowance",
+            "lightning_address": "updated@example.com",
+            "amount": -100,  # Invalid negative amount
+            "currency": "sats",
+            "start_date": "2024-02-01T00:00:00",
+            "frequency_type": "weekly",
+            "next_payment_date": "2024-02-08T00:00:00",
+            "memo": "Updated memo",
+            "active": False
+        }
+        
+        response = client.put("/api/v1/allowance/test_allowance_id", json=invalid_data)
+        assert response.status_code == 422
+    
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_update_allowance_missing_required_fields(self, mock_require_admin_key, mock_get_allowance, client, mock_wallet, mock_allowance):
+        """Test updating allowance with missing required fields"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.return_value = mock_allowance
+        
+        # Test missing name
+        invalid_data = {
+            "lightning_address": "updated@example.com",
+            "amount": 2000,
+            "currency": "sats",
+            "start_date": "2024-02-01T00:00:00",
+            "frequency_type": "weekly",
+            "next_payment_date": "2024-02-08T00:00:00",
+            "memo": "Updated memo",
+            "active": False
+        }
+        
+        response = client.put("/api/v1/allowance/test_allowance_id", json=invalid_data)
+        assert response.status_code == 422
+    
+    @patch('..views_api_minimal.update_allowance')
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_update_allowance_database_error(self, mock_require_admin_key, mock_get_allowance, mock_update_allowance, client, mock_wallet, mock_allowance, update_data):
+        """Test updating allowance when database error occurs"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.return_value = mock_allowance
+        mock_update_allowance.side_effect = Exception("Database connection failed")
+        
+        # Make request
+        response = client.put("/api/v1/allowance/test_allowance_id", json=update_data)
+        
+        # Assertions
+        assert response.status_code == 500
+    
+    @patch('..views_api_minimal.update_allowance')
+    @patch('..views_api_minimal.get_allowance')
+    @patch('..views_api_minimal.require_admin_key')
+    def test_update_allowance_partial_data(self, mock_require_admin_key, mock_get_allowance, mock_update_allowance, client, mock_wallet, mock_allowance, mock_updated_allowance):
+        """Test updating allowance with partial data"""
+        # Setup mocks
+        mock_require_admin_key.return_value = mock_wallet
+        mock_get_allowance.return_value = mock_allowance
+        mock_update_allowance.return_value = mock_updated_allowance
+        
+        # Partial update data - only name and amount
+        partial_data = {
+            "name": "Partially Updated",
+            "lightning_address": "test@example.com",
+            "amount": 1500,
+            "currency": "sats", 
+            "start_date": "2024-01-01T00:00:00",
+            "frequency_type": "daily",
+            "next_payment_date": "2024-01-02T00:00:00",
+            "memo": "Test memo",
+            "active": True
+        }
+        
+        # Make request
+        response = client.put("/api/v1/allowance/test_allowance_id", json=partial_data)
+        
+        # Assertions
+        assert response.status_code == 200


### PR DESCRIPTION
This PR adds comprehensive API testing for all allowance endpoints as requested in issue #2.

## Changes
- Created individual test files for each API endpoint (5 endpoints total)
- Fixed import issues to use views_api_minimal (actual API being used)
- Added comprehensive test coverage including error scenarios
- Tests cover authentication, validation, database errors, and edge cases
- 35+ test scenarios across all CRUD operations
- Fixed authentication patterns to match minimal API structure

Tests created:
- test_api_list_allowances.py - GET /api/v1/allowance
- test_api_get_allowance.py - GET /api/v1/allowance/{id}
- test_api_create_allowance.py - POST /api/v1/allowance
- test_api_update_allowance.py - PUT /api/v1/allowance/{id}
- test_api_delete_allowance.py - DELETE /api/v1/allowance/{id}

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)